### PR TITLE
Added num_cached_keys in default status data

### DIFF
--- a/ByteCodeCache/PhpOpcache.php
+++ b/ByteCodeCache/PhpOpcache.php
@@ -185,6 +185,7 @@ class PhpOpcache implements ByteCodeCacheInterface
                 'hits'   => 0,
                 'misses' => 0,
                 'num_cached_scripts' => 0,
+                'num_cached_keys'    => 0,
                 'max_cached_keys'    => 0
             ),
             'scripts' => array()


### PR DESCRIPTION
We've got this after turned on E_ALL error reporting

Fatal error: Uncaught exception 'Symfony\Component\Debug\Exception\ContextErrorException' with message 'Notice: Undefined index: num_cached_keys' in vendor/matthimatiker/opcache-bundle/ByteCodeCache/PhpOpcache.php on line 121
