### PR TITLE
Dropped 2.3 symfony support and added support for 4.0.

### DIFF
--- a/DataCollector/ByteCodeCacheDataCollector.php
+++ b/DataCollector/ByteCodeCacheDataCollector.php
@@ -66,4 +66,12 @@ class ByteCodeCacheDataCollector extends DataCollector
     {
         return 'matthimatiker_opcache.byte_code_cache';
     }
+
+    /**
+     * Resets this data collector to its initial state.
+     */
+    public function reset()
+    {
+        $this->byteCodeCache = null;
+    }
 }

--- a/Resources/views/DataCollector/partials/DataTable.html.twig
+++ b/Resources/views/DataCollector/partials/DataTable.html.twig
@@ -21,7 +21,7 @@
                     {% if value is iterable and value is not empty %}
                         {% include 'MatthimatikerOpcacheBundle:DataCollector/partials:DataTable.html.twig' with {'data': value, 'withHeader': false} only %}
                     {% else %}
-                        <pre>{{ profiler_dump(value) }}</pre>
+                        {{ dump(value) }}
                     {% endif %}
                 </td>
             </tr>

--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,15 @@
 
     "require": {
         "php": "^7.0.0",
-        "symfony/http-kernel": "^2.3.0 | ^3.0.0",
-        "symfony/config": "^2.3.0 | ^3.0.0",
-        "symfony/dependency-injection": "^2.3.0 | ^3.0.0",
+        "symfony/http-kernel": "^2.7.0 | ^3.0.0 | ^4.0",
+        "symfony/config": "^2.7.0 | ^3.0.0 | ^4.0",
+        "symfony/dependency-injection": "^2.7.0 | ^3.0.0 | ^4.0",
         "twig/twig": "^2.0.0",
-        "symfony/web-profiler-bundle": "^2.3.0 | ^3.0.0",
-        "symfony/templating": "^2.3.0 | ^3.0.0",
-        "symfony/asset": "^2.3.0 | ^3.0.0"
+        "symfony/web-profiler-bundle": "^2.7.0 | ^3.0.0 | ^4.0",
+        "symfony/templating": "^2.7.0 | ^3.0.0 | ^4.0",
+        "symfony/asset": "^2.7.0 | ^3.0.0 | ^4.0",
+        "symfony/templating": "^2.7.0 | ^3.0.0 | ^4.0",
+        "symfony/asset": "^2.7.0 | ^3.0.0 | ^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
I dropped support for Symfony 2.3 because support for Symfony 2.3 ended in May 2017 - IMO there is no need to support this version anymore.