### PR TITLE
Change template references to use newer syntax

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,7 +3,7 @@ services:
         class: Matthimatiker\OpcacheBundle\DataCollector\ByteCodeCacheDataCollector
         arguments: ["@matthimatiker_opcache.byte_code_cache"]
         tags:
-            - { name: "data_collector", template: "MatthimatikerOpcacheBundle:DataCollector:ByteCodeCache", id: "matthimatiker_opcache.byte_code_cache" }
+            - { name: "data_collector", template: "@MatthimatikerOpcache/DataCollector/ByteCodeCache", id: "matthimatiker_opcache.byte_code_cache" }
 
     matthimatiker_opcache.byte_code_cache:
         alias: matthimatiker_opcache.byte_code_cache.php_opcache

--- a/Resources/views/DataCollector/ByteCodeCache.html.twig
+++ b/Resources/views/DataCollector/ByteCodeCache.html.twig
@@ -1,6 +1,6 @@
 {# @see http://symfony.com/doc/current/cookbook/profiler/data_collector.html #}
 {# @var collector \Matthimatiker\OpcacheBundle\DataCollector\ByteCodeCacheDataCollector #}
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% macro number(value, precision = 2) %}
     {%- set template = '%.' ~ precision ~ 'F' -%}
@@ -327,7 +327,7 @@
             <h3 class="tab-title">Configuration</h3>
 
             <div class="tab-content">
-                {% include 'MatthimatikerOpcacheBundle:DataCollector/partials:DataTable.html.twig' with {'data': collector.byteCodeCache.configuration} only %}
+                {% include '@MatthimatikerOpcache/DataCollector/partials/DataTable.html.twig' with {'data': collector.byteCodeCache.configuration} only %}
             </div>
         </div>
 

--- a/Resources/views/DataCollector/partials/DataTable.html.twig
+++ b/Resources/views/DataCollector/partials/DataTable.html.twig
@@ -19,7 +19,7 @@
                 <th>{{ key }}</th>
                 <td>
                     {% if value is iterable and value is not empty %}
-                        {% include 'MatthimatikerOpcacheBundle:DataCollector/partials:DataTable.html.twig' with {'data': value, 'withHeader': false} only %}
+                        {% include '@MatthimatikerOpcache/DataCollector/partials/DataTable.html.twig' with {'data': value, 'withHeader': false} only %}
                     {% else %}
                         {{ dump(value) }}
                     {% endif %}


### PR DESCRIPTION
The old `SomethingBundle:Directory:Filename` syntax appears to no longer work with Symfony 4 + Flex.

Change to using the `@Something/Directory/Filename` syntax which should work back to Symfony 2.7 (at least).
Ref: [Referencing templates in a bundle](https://symfony.com/doc/current/templating.html#referencing-templates-in-a-bundle)

Fixes #22 