### PR TITLE
Test more PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,14 @@ language: php
 php:
     - '7.0'
     - '7.1'
+    - 7.2
+    - 7.3
+    - nightly
+
+matrix:
+    fast_finish: true
+    allow_failures:
+        - php: nightly
 
 before_script:
     - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php:
-    - '7.0'
-    - '7.1'
+    - 7.0
+    - 7.1
     - 7.2
     - 7.3
     - nightly


### PR DESCRIPTION
This PR enables tests against PHP 7.2, 7.3 and 7.4-dev (nightly) on Travis CI. Failures on nightly are allowed.