### PR TITLE
fix root node deprecation in symfony-config > 4.1

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('matthimatiker_opcache');
+        $treeBuilder = new TreeBuilder('matthimatiker_opcache');
+        $rootNode = \method_exists($treeBuilder, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('matthimatiker_opcache');
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for


### PR DESCRIPTION
Symfony 4.2 deprecates constructing a `TreeBuilder` without passing root node information.

This adds a backwards-compatible change to remove the deprecation.

ref https://github.com/symfony/symfony/blob/master/UPGRADE-4.2.md#config